### PR TITLE
use params.id as the _id value for the delete object filter

### DIFF
--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -83,7 +83,7 @@ exports.put = function(req, res, next) {
 };
 
 exports.delete = function(req, res, next) {
-  req.quer.findOneAndRemove({}, this.delete_options, function(err, obj) {
+  req.quer.findOneAndRemove({_id: req.params.id}, this.delete_options, function(err, obj) {
     if (err) {
       exports.respond(res, 500, err);
     }


### PR DESCRIPTION
It seems that the findOneAndRemove function wasn't being passed a filter and delete seemed to be failing. Passing in the object with _id attribute seemed to work.
