### PR TITLE
Don't limit _id to the mongoDB default one

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -212,9 +212,9 @@ Model.registerRoutes = function(app, prefix, path, routeObj) {
        * aka prettify this
        */
       if (route.detail) {
-        app[key](prefix + '/:id' + path , handlerlist);
+        app[key](prefix + '/:id([0-9a-fA-F]{0,24})' + path , handlerlist);
       } else if (detailGet) {
-        app[key](prefix + '/:id?', handlerlist);
+        app[key](prefix + '/:id([0-9a-fA-F]{0,24}$)?', handlerlist);
       } else {
         app[key](prefix + path, handlerlist);
       }


### PR DESCRIPTION
Hi there =)

I'm currently working on building a REST API with node for a project and it comes that the `_id` we use is not the default one created by mongoDB, but a custom one. In fact, we are using auto-incremented numbers in this case.

Unfortunately, it didn't work with your splendid module because the code only expect a specific format for `:id`. We dropped off this limitation because ID can be something else, such like a `"string"` or a `"number"`, and the API should still working.

So I'm proposing this correction to you, in case there would be no specific reason for ID to be limited to the default one. Tell me if there is anything wrong here.

By the way: thanks a lot for your module, very useful =)
