### PR TITLE
Make mongoose a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,14 +2,15 @@
   "name": "node-restful",
   "description": "A library for making REST API's in node.js with express",
   "version": "0.1.14",
-  "dependencies": {
-    "mongoose": "3.5.4"
+  "peerDependencies": {
+    "mongoose": "~3"
   },
   "devDependencies": {
     "express": "3.1.0",
     "mongodb": "1.2.14",
     "jade": "0.28.1",
     "mocha": "1.8.1",
+    "mongoose": "~3",
     "should": "1.2.1",
     "supertest": "0.5.1",
     "sinon": "1.5.2",


### PR DESCRIPTION
Make mongoose a peer dependency rather than a regular dependency. This will fix issue #42. You can get more info about npm peer dependencies at http://blog.nodejs.org/2013/02/07/peer-dependencies.
