### PR TITLE
adds nocase query to wrap value in case insensitive regex

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -32,6 +32,7 @@ var methods = ['get', 'post', 'put', 'delete'], // All HTTP methods, PATCH not c
       'lte': query('lte'),
       'ne': query('ne'),
       'regex': query('regex'),
+      'nocase': query('regex'),
       'in': query('in')
     });
   defaults = function() {
@@ -446,6 +447,10 @@ function filterable(props, subfilters) {
       // Turn data into array for $in clause
       if (filter_func === 'in') {
         data = data.split(',');
+      }
+
+      if (filter_func === 'nocase') {
+        return subfilters[filter_func](new RegExp(data, 'i'), quer.where(field[0]));
       }
 
       return subfilters[filter_func](data, quer.where(field[0]));

--- a/test/fixtures/data.js
+++ b/test/fixtures/data.js
@@ -89,5 +89,10 @@ exports.movies = [
     _id: new ObjectId(),
     title: "Title14",
       year: 2009
+  },
+  {
+    _id: new ObjectId(),
+    title: "Godzilla",
+      year: 2014
   }
 ];

--- a/test/model.filters.js
+++ b/test/model.filters.js
@@ -146,6 +146,16 @@ describe('Model', function() {
           done();
         });
     });
+    it('should filter fields using nocase', function(done) {
+      request(app)
+        .get('/api/movies?title__nocase=godzilla')
+        .end(function(err, res) {
+          res.body.forEach(function(movie) {
+            movie.title.should.include('Godzilla');
+          });
+          done();
+        });
+    });
     it('should populate an objectId', function(done) {
       request(app)
         .get('/api/movies/' + movie1._id + '?populate=creator')


### PR DESCRIPTION
I was having problems getting `?location_regex=/boise/i` to work so I created a custom querystring class `nocase`.
