### PR TITLE
fixed rendering of html files after setting the templateRoot manually

### DIFF
--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -7,7 +7,7 @@ exports.last = function(req, res, next) {
     if (req.body.format === 'js') {
       return res.send(res.locals.bundle);
     } else if (req.body.format === 'html' || req.query.format === 'html') {
-      return res.render(this.templateRoot + '/' + req.templatePath, res.locals.bundle);
+      return res.render(req.quer.model.templateRoot + '/' + req.templatePath, res.locals.bundle);
     } else {
       return res.status(res.locals.status_code).json(res.locals.bundle);
     }


### PR DESCRIPTION
Thanks for your awesome module, it makes our work way more easy.
We generate the models via json-files and feed it to your module. Each json-file needs a different rootPath, so we had to fix this. :)
