### PR TITLE
Provide the option to choose for 1 atomic update/delete operation.

### DIFF
--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -73,23 +73,64 @@ exports.put = function(req, res, next) {
     delete req.body._id;
   }
 
-  req.quer.findOneAndUpdate({}, req.body, this.update_options, function(err, newObj) {
-    if (err) {
-      exports.respond(res, 500, err);
-    }
-    exports.respondOrErr(res, 400, !newObj && exports.objectNotFound(), 200, newObj);
-    next();
-  });
+  // Update in 1 atomic operation on the database if not specified otherwise
+  if (this.shouldUseAtomicUpdate) {
+    req.quer.findOneAndUpdate({}, req.body, this.update_options, function(err, newObj) {
+      if (err) {
+        exports.respond(res, 500, err);
+      }
+      exports.respondOrErr(res, 400, !newObj && exports.objectNotFound(), 200, newObj);
+      next();
+    });
+  } else {
+    // Preform the update in two operations allowing mongoose to fire its schema update hook
+    req.quer.findOne({"_id": req.params.id}, function(err, docToUpdate) {
+      if (err) {
+        exports.respond(res, 500, err);
+      }
+      var objNotFound = !docToUpdate && exports.objectNotFound();
+      if (objNotFound) {
+        exports.respond(res, 404, objNotFound);
+        next();
+      }
+
+      docToUpdate.set(req.body);
+      docToUpdate.save(function (err, obj) {
+        exports.respondOrErr(res, 400, err, 200, obj);
+        next();
+      });
+    });
+  }
 };
 
 exports.delete = function(req, res, next) {
-  req.quer.findOneAndRemove({}, this.delete_options, function(err, obj) {
-    if (err) {
-      exports.respond(res, 500, err);
-    }
-    exports.respondOrErr(res, 400, !obj && exports.objectNotFound(), 204, {});
-    next();
-  });
+  // Delete in 1 atomic operation on the database if not specified otherwise
+  if (this.shouldUseAtomicUpdate) {
+    req.quer.findOneAndRemove({}, this.delete_options, function(err, obj) {
+      if (err) {
+        exports.respond(res, 500, err);
+      }
+      exports.respondOrErr(res, 400, !obj && exports.objectNotFound(), 204, {});
+      next();
+    });
+  } else {
+    // Preform the remove in two steps allowing mongoose to fire its schema update hook
+    req.quer.findOne({"_id": req.params.id}, function(err, docToRemove) {
+      if (err) {
+        exports.respond(res, 500, err);
+      }
+      var objNotFound = !docToRemove && exports.objectNotFound();
+      if (objNotFound) {
+        exports.respond(res, 404, objNotFound);
+        next();
+      }
+
+      docToRemove.remove(function (err, obj) {
+        exports.respondOrErr(res, 400, err, 204, {});
+        next();
+      });
+    });
+  }
 };
 
 // I'm going to leave these here because it might be nice to have standardized

--- a/lib/model.js
+++ b/lib/model.js
@@ -43,7 +43,8 @@ var methods = ['get', 'post', 'put', 'delete'], // All HTTP methods, PATCH not c
       update_options: {},
       remove_options: {},
       templateRoot: '',
-      shouldIncludeSchema: true
+      shouldIncludeSchema: true,
+      shouldUseAtomicUpdate: true
     };
   };
 


### PR DESCRIPTION
As mentioned in issue #73 i've implemented an option which defaults to the current use, but allows you to choose for 2 step update or remove of documents, in order to allow mongoose to call the pre and post hooks on a schema.

It is up and running in our application, as mentioned in the issue, we use it for document versioning where new versions are saved after every save or remove call. 

I can add or refactor if you want.  Let me know what you think.
