### PR TITLE
added body-parser to dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Register mongoose resources and default RESTful routes are automatically made
 ```js
 var express = require('express'),
     restful = require('node-restful'),
+    bodyParser = require('body-parser'),
     mongoose = restful.mongoose;
 var app = express();
 

--- a/package.json
+++ b/package.json
@@ -6,15 +6,16 @@
     "mongoose": "~3"
   },
   "devDependencies": {
+    "body-parser": "^1.12.4",
     "express": "3.1.0",
-    "mongodb": "1.2.14",
     "jade": "0.28.1",
     "mocha": "1.8.1",
+    "mongodb": "1.2.14",
     "mongoose": "~3",
+    "pow-mongoose-fixtures": "0.3.0",
     "should": "1.2.1",
-    "supertest": "0.5.1",
     "sinon": "1.5.2",
-    "pow-mongoose-fixtures": "0.3.0"
+    "supertest": "0.5.1"
   },
   "keywords": [
     "node-restful",


### PR DESCRIPTION
Hey guys, I noticed that in the README body-parser was not a dependency, I added it and put it in the package.json as well. Let me know if this is not necessary. 