### PR TITLE
Fix 404 related errors

### DIFF
--- a/examples/movies/index.js
+++ b/examples/movies/index.js
@@ -36,6 +36,7 @@ var movie = app.movie = restful.model("movies", mongoose.Schema({
     title: { type: 'string', required: true },
     year: { type: 'number', required: true },
     creator: {type: 'ObjectId', ref: 'users' },
+    genre: {type: 'ObjectId', ref: 'genres'},
     comments: [{
       body: {type: 'String'},
       date: {type: 'Date'},
@@ -101,8 +102,17 @@ movie.methods([
   .after('put', noop)
   .after('recommend', after)
   .after('athirdroute', after);
+
+var genre = app.genre = restful.model("genres", mongoose.Schema({
+    name: { type: 'string', required: true }
+  }));
+
+genre.methods(['get', 'put', 'delete']);
+genre.shouldUseAtomicUpdate = false;
+
 user.register(app, '/users');
 movie.register(app, '/api/movies');
+genre.register(app, '/api/genres');
 
 if (!module.parent) {
   app.listen(3000);

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -32,7 +32,13 @@ exports.schema = function(req, res, next) {
 
 exports.get = function(req, res, next) {
   req.quer.exec(function(err, list) {
-    exports.respondOrErr(res, 500, err, 200, (req.params.id && list && list.length > 0) ? list[0] : list);
+    if (err) {
+      exports.respond(res, 500, err);
+    } else if (req.params.id) {
+      exports.respondOrErr(res, 404, !list && exports.objectNotFound(), 200, (list && list.length) ? list[0] : list);
+    } else {
+      exports.respondOrErr(res, 500, err, 200, list);
+    }
     next();
   });
 };
@@ -91,7 +97,7 @@ exports.put = function(req, res, next) {
       var objNotFound = !docToUpdate && exports.objectNotFound();
       if (objNotFound) {
         exports.respond(res, 404, objNotFound);
-        next();
+        return next();
       }
 
       docToUpdate.set(req.body);
@@ -122,7 +128,7 @@ exports.delete = function(req, res, next) {
       var objNotFound = !docToRemove && exports.objectNotFound();
       if (objNotFound) {
         exports.respond(res, 404, objNotFound);
-        next();
+        return next();
       }
 
       docToRemove.remove(function (err, obj) {

--- a/test/model.js
+++ b/test/model.js
@@ -99,6 +99,24 @@ describe('Model', function() {
           });
         });
     });
+    it('should fail on GET missing resource', function(done) {
+      request(app)
+        .get('/api/movies/55e8169191ad293c221a6c9d')
+        .expect(404, done);
+    });
+    it('should fail on PUT missing resource (shouldUseAtomicUpdate=false)', function(done) {
+      request(app)
+        .put('/api/genres/55e8169191ad293c221a6c9d')
+        .send({
+          name: "Mysterious genre"
+        })
+        .expect(404, done);
+    });
+    it('should fail on DELETE missing resource (shouldUseAtomicUpdate=false)', function(done) {
+      request(app)
+        .del('/api/genres/55e8169191ad293c221a6c9d')
+        .expect(404, done);
+    });
     it('should fail on PUT without filter on unsortable model', function(done) {
       request(app)
         .put('/api/movies')


### PR DESCRIPTION
There are scenarios where it's expected to get 404 response but getting something else:

- PUT to not existing resource (``shouldUseAtomicUpdate=false``)
- DELETE not existing resource (``shouldUseAtomicUpdate=false``)
- GET not existing resource

Those are fixed here (see tests)