### PR TITLE
Fixing issue with DELETE and PUT METHOD were working without any params.id

### DIFF
--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -83,11 +83,10 @@ exports.post = function(req, res, next) {
 
 exports.put = function(req, res, next) {
   //before PUT atleast check if params.id is there or not
-  if (req.params.id && !mongoose.Types.ObjectId.isValid(req.params.id)) {
-    exports.respond(res, 400, exports.badRequest());
-    next();
+  if ((!req.params.id || !mongoose.Types.ObjectId.isValid(req.params.id)) && this.isSecureDelete) {
+        exports.respond(res, 400, exports.badRequest());
+        return next();
   }
-
   // Remove immutable ObjectId from update attributes to prevent request failure
   if (req.body._id && req.body._id === req.params.id) {
     delete req.body._id;
@@ -129,9 +128,9 @@ exports.put = function(req, res, next) {
 exports.delete = function(req, res, next) {
     //before delete atleast check if params.id is there or not. Or it will deleting entire model
     //if you want to allow it you can set in in the model isSecureDelete=false
-    if (req.params.id && !mongoose.Types.ObjectId.isValid(req.params.id) && this.isSecureDelete) {
+    if ((!req.params.id || !mongoose.Types.ObjectId.isValid(req.params.id)) && this.isSecureDelete) {
         exports.respond(res, 400, exports.badRequest());
-        next();
+        return next();
     }
 
   // Delete in 1 atomic operation on the database if not specified otherwise

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -82,6 +82,12 @@ exports.post = function(req, res, next) {
 };
 
 exports.put = function(req, res, next) {
+  //before PUT atleast check if params.id is there or not
+  if (req.params.id && !mongoose.Types.ObjectId.isValid(req.params.id)) {
+    exports.respond(res, 400, exports.badRequest());
+    next();
+  }
+
   // Remove immutable ObjectId from update attributes to prevent request failure
   if (req.body._id && req.body._id === req.params.id) {
     delete req.body._id;
@@ -121,6 +127,13 @@ exports.put = function(req, res, next) {
 };
 
 exports.delete = function(req, res, next) {
+    //before delete atleast check if params.id is there or not. Or it will deleting entire model
+    //if you want to allow it you can set in in the model isSecureDelete=false
+    if (req.params.id && !mongoose.Types.ObjectId.isValid(req.params.id) && this.isSecureDelete) {
+        exports.respond(res, 400, exports.badRequest());
+        next();
+    }
+
   // Delete in 1 atomic operation on the database if not specified otherwise
   if (this.shouldUseAtomicUpdate) {
     req.quer.findOneAndRemove({}, this.delete_options, function(err, obj) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -56,7 +56,8 @@ var methods = ['get', 'post', 'put', 'delete'], // All HTTP methods, PATCH not c
       remove_options: {},
       templateRoot: '',
       shouldIncludeSchema: true,
-      shouldUseAtomicUpdate: true
+      shouldUseAtomicUpdate: true,
+      isSecureDelete:true
     };
   };
 


### PR DESCRIPTION
Fixing issue #144

As issue mentioned from the DELETE method you were able to delete entire collection data just by skipping the OBJECT ID in the URL 

Fix it in both handlers PUT and DELETE. Now for PUT and DELETE request.params.id is mandatory if not it will throw 400 [bad request]

However for development purpose and any other such reasons I have kept a parameter in 

`defaults.isSecureDelete=true`

which can be overridden at the time of the model creation. 



